### PR TITLE
fix: enable autocommit for postgres to avoid concurrent transaction issues

### DIFF
--- a/backend/api/core/agent/persistence.py
+++ b/backend/api/core/agent/persistence.py
@@ -30,7 +30,7 @@ async def checkpointer_context(
     # A compatible psycopg connection is created via the connection pool to connect to the checkpointer.
     async with AsyncConnectionPool(
         conninfo=conn_str,
-        kwargs=dict(prepare_threshold=None),
+        kwargs=dict(prepare_threshold=None, autocommit=True),
     ) as pool:
         checkpointer = AsyncPostgresSaver(pool)
         try:


### PR DESCRIPTION
This fixes the following error when setting up your own postgres instance:

```
ERROR:  CREATE INDEX CONCURRENTLY cannot run inside a transaction block
STATEMENT:  
            CREATE INDEX CONCURRENTLY IF NOT EXISTS checkpoints_thread_id_idx ON checkpoints(thread_id);
           
ERROR:  relation "checkpoints" does not exist at character 1308
```